### PR TITLE
Don't set this.body

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,6 @@ var initialize = function(opts) {
   return function *(next) {
     if (this.method !== 'GET' && this.method !== 'DELETE') {
       this.request.body = yield parse.json(this, opts);
-      this.body = this.request.body;
     }
 
     yield next;


### PR DESCRIPTION
koa-json-body shouldn't set `this.body` since it's a shortcut for the response body. While useful for debugging, this behaviour can be confusing.
