### PR TITLE
Allow `DELETE` bodies

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -16,7 +16,7 @@ module.exports = function (opts) {
       ctx.request.body = {}
     }
 
-    if (ctx.method === 'GET' || ctx.method === 'DELETE') {
+    if (ctx.method === 'GET') {
       return next()
     }
 

--- a/test/integration.spec.js
+++ b/test/integration.spec.js
@@ -24,12 +24,6 @@ describe('integration', function () {
         .expect(204)
     })
 
-    it('does nothing on a DELETE request', function () {
-      return request(app.listen())
-        .delete('/')
-        .expect(204)
-    })
-
     it('parses JSON Objects and assigns it to ctx.request.body', function () {
       return request(app.listen())
         .post('/')
@@ -83,11 +77,16 @@ describe('integration', function () {
         .expect({})
     })
 
-    it('sets ctx.request.body to {} on a DELETE request', function () {
+    it('allows body on a DELETE request', function () {
       return request(app.listen())
         .delete('/')
+        .send({
+          foo: 'bar'
+        })
         .expect(200)
-        .expect({})
+        .expect({
+          foo: 'bar'
+        })
     })
 
     it('parses JSON Objects and assigns it to ctx.request.body', function () {


### PR DESCRIPTION
As per on: https://tools.ietf.org/html/rfc7231#section-4.3.5. 

> Bodies on DELETE requests have no defined semantics.  Note that sending a body on a DELETE request might cause some existing implementations to reject the request.

My understanding is that _we can_ support bodies on **DELETE** requests (HTTP/1.1) since the spec doesn't explicitly state that we shouldn't.